### PR TITLE
Criação e Listagem de Usuário

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -2,6 +2,7 @@ import {
   InternalServerError,
   MethodNotAllowedError,
   ValidationError,
+  NotFoundError,
 } from 'infra/errors.js'
 
 function onNoMatchHandler(req, res) {
@@ -10,7 +11,7 @@ function onNoMatchHandler(req, res) {
 }
 
 function onErrorHandler(error, req, res) {
-  if (error instanceof ValidationError) {
+  if (error instanceof ValidationError || error instanceof NotFoundError) {
     return res.status(error.statusCode).json(error)
   }
 

--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,4 +1,8 @@
-import { InternalServerError, MethodNotAllowedError } from 'infra/errors.js'
+import {
+  InternalServerError,
+  MethodNotAllowedError,
+  ValidationError,
+} from 'infra/errors.js'
 
 function onNoMatchHandler(req, res) {
   const publicErrorObject = new MethodNotAllowedError()
@@ -6,6 +10,10 @@ function onNoMatchHandler(req, res) {
 }
 
 function onErrorHandler(error, req, res) {
+  if (error instanceof ValidationError) {
+    return res.status(error.statusCode).json(error)
+  }
+
   const publicErrorObject = new InternalServerError({
     statusCode: error.statusCode,
     cause: error,

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -61,6 +61,28 @@ export class ValidationError extends Error {
   }
 }
 
+export class NotFoundError extends Error {
+  constructor({ cause, message, action }) {
+    super(message || 'Não foi possível encontrar este recurso no sistema.', {
+      cause,
+    })
+
+    this.name = 'NotFoundError'
+    this.action =
+      action || 'Verifique se os parâmetros informados estão corretos.'
+    this.statusCode = 404
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    }
+  }
+}
+
 export class MethodNotAllowedError extends Error {
   constructor() {
     super('Método não permitido para este endpoint.')

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -40,6 +40,27 @@ export class ServiceError extends Error {
   }
 }
 
+export class ValidationError extends Error {
+  constructor({ cause, message, action }) {
+    super(message || 'Um erro de validação ocorreu.', {
+      cause,
+    })
+
+    this.name = 'ValidationError'
+    this.action = action || 'Ajuste os dados informados e tente novamente.'
+    this.statusCode = 400
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    }
+  }
+}
+
 export class MethodNotAllowedError extends Error {
   constructor() {
     super('Método não permitido para este endpoint.')

--- a/infra/migrations/1735779198731_test-migration.js
+++ b/infra/migrations/1735779198731_test-migration.js
@@ -1,8 +1,0 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable camelcase */
-
-exports.shorthands = undefined
-
-exports.up = (pgm) => {}
-
-exports.down = (pgm) => {}

--- a/infra/migrations/1742964836103_create-users.js
+++ b/infra/migrations/1742964836103_create-users.js
@@ -1,0 +1,44 @@
+exports.up = (pgm) => {
+  pgm.createTable('users', {
+    id: {
+      type: 'uuid',
+      primaryKey: true,
+      default: pgm.func('gen_random_uuid()'),
+    },
+
+    // For reference, Github usernames can have up to 39 characters.
+    username: {
+      type: 'varchar(30)',
+      notNull: true,
+      unique: true,
+    },
+
+    // Why 254 in length? https://stackoverflow.com/a/1199238
+    email: {
+      type: 'varchar(254)',
+      notNull: true,
+      unique: true,
+    },
+
+    // Why 60 in length? https://www.npmjs.com/package/bcrypt#hash-info
+    password: {
+      type: 'varchar(60)',
+      notNull: true,
+    },
+
+    // Why timestamp with time zone? https://justatheory.com/2012/04/postgres-use-timestamptz/
+    created_at: {
+      type: 'timestamptz',
+      notNull: true,
+      default: pgm.func("timezone('UTC', now())"),
+    },
+
+    updated_at: {
+      type: 'timestamptz',
+      notNull: true,
+      default: pgm.func("timezone('UTC', now())"),
+    },
+  })
+}
+
+exports.down = false

--- a/models/migrator.js
+++ b/models/migrator.js
@@ -6,7 +6,7 @@ const defaultMigrationOptions = {
   dryRun: true,
   dir: resolve('infra', 'migrations'),
   direction: 'up',
-  verbose: true,
+  log: () => {},
   migrationsTable: 'pgmigrations',
 }
 

--- a/models/user.js
+++ b/models/user.js
@@ -1,0 +1,78 @@
+import database from 'infra/database.js'
+import { ValidationError } from 'infra/errors.js'
+
+async function create(userInputValues) {
+  await validateUniqueEmail(userInputValues.email)
+  await validateUniqueUsername(userInputValues.username)
+
+  const newUser = await runInsertQuery(userInputValues)
+  return newUser
+
+  async function validateUniqueEmail(email) {
+    const results = await database.query({
+      text: `
+        SELECT
+          email
+        FROM
+          users
+        WHERE
+          LOWER(email) = LOWER($1)
+      ;`,
+      values: [email],
+    })
+
+    if (results.rowCount > 0) {
+      throw new ValidationError({
+        message: 'O email informado já está em uso.',
+        action: 'Utilize outro email para realizar o cadastro.',
+      })
+    }
+  }
+
+  async function validateUniqueUsername(username) {
+    const results = await database.query({
+      text: `
+        SELECT
+          username
+        FROM
+          users
+        WHERE
+          LOWER(username) = LOWER($1)
+      ;`,
+      values: [username],
+    })
+
+    if (results.rowCount > 0) {
+      throw new ValidationError({
+        message: 'O username informado já está em uso.',
+        action: 'Utilize outro username para realizar o cadastro.',
+      })
+    }
+  }
+
+  async function runInsertQuery(userInputValues) {
+    const results = await database.query({
+      text: `
+        INSERT INTO
+          users (username, email, password)
+        VALUES 
+          ($1, $2, $3)
+        RETURNING
+          *
+      ;`,
+      values: [
+        userInputValues.username,
+        userInputValues.email,
+        userInputValues.password,
+      ],
+    })
+
+    return results.rows[0]
+  }
+}
+
+const user = {
+  create,
+}
+
+export default user

--- a/models/user.js
+++ b/models/user.js
@@ -1,5 +1,35 @@
 import database from 'infra/database.js'
-import { ValidationError } from 'infra/errors.js'
+import { ValidationError, NotFoundError } from 'infra/errors.js'
+
+async function findOneByUsername(username) {
+  const userFound = await runSelectQuery(username)
+  return userFound
+
+  async function runSelectQuery(username) {
+    const results = await database.query({
+      text: `
+        SELECT
+          *
+        FROM
+          users
+        WHERE
+          LOWER(username) = LOWER($1)
+        LIMIT
+          1
+      ;`,
+      values: [username],
+    })
+
+    if (results.rowCount === 0) {
+      throw new NotFoundError({
+        message: 'O username informado não foi encontrado no sistema.',
+        action: 'Verifique se o username está correto.',
+      })
+    }
+
+    return results.rows[0]
+  }
+}
 
 async function create(userInputValues) {
   await validateUniqueEmail(userInputValues.email)
@@ -73,6 +103,7 @@ async function create(userInputValues) {
 
 const user = {
   create,
+  findOneByUsername,
 }
 
 export default user

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "pg": "8.12.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "swr": "2.2.5"
+        "swr": "2.2.5",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@commitlint/cli": "19.4.0",
@@ -11233,6 +11234,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "pg": "8.12.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "swr": "2.2.5"
+    "swr": "2.2.5",
+    "uuid": "11.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "19.4.0",

--- a/pages/api/v1/users/[username]/index.js
+++ b/pages/api/v1/users/[username]/index.js
@@ -1,0 +1,16 @@
+import { createRouter } from 'next-connect'
+import controller from 'infra/controller.js'
+import user from 'models/user.js'
+
+const router = createRouter()
+router.get(getHandler)
+
+export default router.handler(controller.errorHandlers)
+
+async function getHandler(req, res) {
+  const { username } = req.query
+
+  const userFound = await user.findOneByUsername(username)
+
+  return res.status(200).json(userFound)
+}

--- a/pages/api/v1/users/index.js
+++ b/pages/api/v1/users/index.js
@@ -1,0 +1,14 @@
+import { createRouter } from 'next-connect'
+import controller from 'infra/controller.js'
+import user from 'models/user.js'
+
+const router = createRouter()
+router.post(postHandler)
+
+export default router.handler(controller.errorHandlers)
+
+async function postHandler(req, res) {
+  const userInputValues = req.body
+  const newUser = await user.create(userInputValues)
+  return res.status(201).json(newUser)
+}

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -1,0 +1,100 @@
+import { version as uuidVersion } from 'uuid'
+import orchestrator from 'tests/orchestrator.js'
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices()
+  await orchestrator.clearDatabase()
+  await orchestrator.runPendingMigrations()
+})
+
+describe('GET /api/v1/users/[username]', () => {
+  describe('Anonymous user', () => {
+    test('With exact case match', async () => {
+      const response1 = await fetch('http://localhost:3000/api/v1/users', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          username: 'MesmoCase',
+          email: 'mesmo.case@test.com',
+          password: 'senha123',
+        }),
+      })
+
+      expect(response1.status).toBe(201)
+
+      const response2 = await fetch(
+        'http://localhost:3000/api/v1/users/MesmoCase'
+      )
+
+      expect(response2.status).toBe(200)
+
+      const response2Body = await response2.json()
+      expect(response2Body).toEqual({
+        id: response2Body.id,
+        username: 'MesmoCase',
+        email: 'mesmo.case@test.com',
+        password: 'senha123',
+        created_at: response2Body.created_at,
+        updated_at: response2Body.updated_at,
+      })
+
+      expect(uuidVersion(response2Body.id)).toBe(4)
+      expect(Date.parse(response2Body.created_at)).not.toBeNaN()
+      expect(Date.parse(response2Body.updated_at)).not.toBeNaN()
+    })
+
+    test('With case mismatch', async () => {
+      const response1 = await fetch('http://localhost:3000/api/v1/users', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          username: 'CaseDiferente',
+          email: 'case.diferente@test.com',
+          password: 'senha123',
+        }),
+      })
+
+      expect(response1.status).toBe(201)
+
+      const response2 = await fetch(
+        'http://localhost:3000/api/v1/users/casediferente'
+      )
+
+      expect(response2.status).toBe(200)
+
+      const response2Body = await response2.json()
+      expect(response2Body).toEqual({
+        id: response2Body.id,
+        username: 'CaseDiferente',
+        email: 'case.diferente@test.com',
+        password: 'senha123',
+        created_at: response2Body.created_at,
+        updated_at: response2Body.updated_at,
+      })
+
+      expect(uuidVersion(response2Body.id)).toBe(4)
+      expect(Date.parse(response2Body.created_at)).not.toBeNaN()
+      expect(Date.parse(response2Body.updated_at)).not.toBeNaN()
+    })
+
+    test('With nonexistent username', async () => {
+      const response = await fetch(
+        'http://localhost:3000/api/v1/users/UsuarioInexistente'
+      )
+
+      expect(response.status).toBe(404)
+
+      const responseBody = await response.json()
+      expect(responseBody).toEqual({
+        name: 'NotFoundError',
+        message: 'O username informado não foi encontrado no sistema.',
+        action: 'Verifique se o username está correto.',
+        status_code: 404,
+      })
+    })
+  })
+})

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -1,0 +1,118 @@
+import { version as uuidVersion } from 'uuid'
+import orchestrator from 'tests/orchestrator.js'
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices()
+  await orchestrator.clearDatabase()
+  await orchestrator.runPendingMigrations()
+})
+
+describe('POST /api/v1/users', () => {
+  describe('Anonymous user', () => {
+    test('With unique and valid data', async () => {
+      const response = await fetch('http://localhost:3000/api/v1/users', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          username: 'testanildo',
+          email: 'testanildo@test.com',
+          password: 'senha123',
+        }),
+      })
+
+      expect(response.status).toBe(201)
+
+      const responseBody = await response.json()
+      expect(responseBody).toEqual({
+        id: responseBody.id,
+        username: 'testanildo',
+        email: 'testanildo@test.com',
+        password: 'senha123',
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+      })
+
+      expect(uuidVersion(responseBody.id)).toBe(4)
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN()
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN()
+    })
+
+    test('With duplicated "email"', async () => {
+      const response1 = await fetch('http://localhost:3000/api/v1/users', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          username: 'emailduplicado1',
+          email: 'duplicado@test.com',
+          password: 'senha123',
+        }),
+      })
+
+      expect(response1.status).toBe(201)
+
+      const response2 = await fetch('http://localhost:3000/api/v1/users', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          username: 'emailduplicado2',
+          email: 'Duplicado@test.com',
+          password: 'senha123',
+        }),
+      })
+
+      expect(response2.status).toBe(400)
+
+      const response2Body = await response2.json()
+      expect(response2Body).toEqual({
+        name: 'ValidationError',
+        message: 'O email informado já está em uso.',
+        action: 'Utilize outro email para realizar o cadastro.',
+        status_code: 400,
+      })
+    })
+
+    test('With duplicated "username"', async () => {
+      const response1 = await fetch('http://localhost:3000/api/v1/users', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          username: 'duplicado',
+          email: 'userduplicado1@test.com',
+          password: 'senha123',
+        }),
+      })
+
+      expect(response1.status).toBe(201)
+
+      const response2 = await fetch('http://localhost:3000/api/v1/users', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          username: 'Duplicado',
+          email: 'userduplicado2@test.com',
+          password: 'senha123',
+        }),
+      })
+
+      expect(response2.status).toBe(400)
+
+      const response2Body = await response2.json()
+      expect(response2Body).toEqual({
+        name: 'ValidationError',
+        message: 'O username informado já está em uso.',
+        action: 'Utilize outro username para realizar o cadastro.',
+        status_code: 400,
+      })
+    })
+  })
+})

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -1,5 +1,6 @@
 import retry from 'async-retry'
 import database from 'infra/database.js'
+import migrator from 'models/migrator.js'
 
 async function waitForAllServices() {
   await awaitForWebServer()
@@ -24,9 +25,14 @@ async function clearDatabase() {
   await database.query('drop schema public cascade; create schema public;')
 }
 
+async function runPendingMigrations() {
+  await migrator.runPendingMigrations()
+}
+
 const orchestrator = {
   waitForAllServices,
   clearDatabase,
+  runPendingMigrations,
 }
 
 export default orchestrator


### PR DESCRIPTION
- Cria model `user`
- Cria 2 novos endpoints:
  - `POST` `/api/v1/users`
  - `GET` `/api/v1/users/[username]`
- Remove `migration` de teste
- Cria `migration` que cria a tabela `users`
- Cria dois novos erros customizados:
  - `ValidationError`
  - `NotFoundError`
- Adiciona novo método ao `orchestrator`:
  - `runPendingMigrations`
  - Silencia os logs do migrator